### PR TITLE
Add Nuke build project and GitVersion config

### DIFF
--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "ApiKit.sln"
+}

--- a/ApiKit.sln
+++ b/ApiKit.sln
@@ -11,26 +11,63 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9FFE4A54
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiKit.Tests", "tests\ApiKit.Tests\ApiKit.Tests.csproj", "{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{DEE5DD87-39C1-BF34-B639-A387DCCF972B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "_build", "build\_build.csproj", "{264A9A56-1281-4E36-BC32-F96969D8504F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Debug|x64.Build.0 = Debug|Any CPU
+		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Debug|x86.Build.0 = Debug|Any CPU
 		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Release|x64.ActiveCfg = Release|Any CPU
+		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Release|x64.Build.0 = Release|Any CPU
+		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Release|x86.ActiveCfg = Release|Any CPU
+		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9}.Release|x86.Build.0 = Release|Any CPU
 		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Debug|x64.Build.0 = Debug|Any CPU
+		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Debug|x86.Build.0 = Debug|Any CPU
 		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Release|x64.ActiveCfg = Release|Any CPU
+		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Release|x64.Build.0 = Release|Any CPU
+		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Release|x86.ActiveCfg = Release|Any CPU
+		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576}.Release|x86.Build.0 = Release|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Debug|x64.Build.0 = Debug|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Debug|x86.Build.0 = Debug|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Release|x64.ActiveCfg = Release|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Release|x64.Build.0 = Release|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Release|x86.ActiveCfg = Release|Any CPU
+		{264A9A56-1281-4E36-BC32-F96969D8504F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EA603DD9-BCB0-4B1D-AE02-EB3B8402C9C9} = {38FB9C4A-EF95-4171-B573-1167CD813A3B}
 		{5EF6ECE4-D8F3-4FD7-90E1-E1A53A524576} = {9FFE4A54-DEBD-4E92-A1ED-42E3475704C5}
+		{264A9A56-1281-4E36-BC32-F96969D8504F} = {DEE5DD87-39C1-BF34-B639-A387DCCF972B}
 	EndGlobalSection
 EndGlobal

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,13 @@
+workflow: GitHubFlow/v1
+mode: ContinuousDeployment
+# Version floor set by tagging v1.0.0 on the first release commit
+tag-prefix: v
+
+branches:
+  main:
+    label: ''
+    prevent-increment:
+      when-current-commit-tagged: true
+  feature:
+    label: '{BranchName}'
+    increment: Inherit

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,7 @@
+:; set -eo pipefail
+:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+:; ${SCRIPT_DIR}/build.sh "$@"
+:; exit $?
+
+@ECHO OFF
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$BuildArguments
+)
+
+Write-Output "PowerShell $($PSVersionTable.PSEdition) version $($PSVersionTable.PSVersion)"
+
+Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { Write-Error $_ -ErrorAction Continue; exit 1 }
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+$BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
+$TempDirectory = "$PSScriptRoot\\.nuke\temp"
+
+$DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
+$DotNetChannel = "STS"
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function ExecSafe([scriptblock] $cmd) {
+    & $cmd
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
+     $(dotnet --version) -and $LASTEXITCODE -eq 0) {
+    $env:DOTNET_EXE = (Get-Command "dotnet").Path
+}
+else {
+    # Download install script
+    $DotNetInstallFile = "$TempDirectory\dotnet-install.ps1"
+    New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
+
+    # If global.json exists, load expected version
+    if (Test-Path $DotNetGlobalFile) {
+        $DotNetGlobal = $(Get-Content $DotNetGlobalFile | Out-String | ConvertFrom-Json)
+        if ($DotNetGlobal.PSObject.Properties["sdk"] -and $DotNetGlobal.sdk.PSObject.Properties["version"]) {
+            $DotNetVersion = $DotNetGlobal.sdk.version
+        }
+    }
+
+    # Install by channel or version
+    $DotNetDirectory = "$TempDirectory\dotnet-win"
+    if (!(Test-Path variable:DotNetVersion)) {
+        ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
+    } else {
+        ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
+    }
+    $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+}
+
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+}
+
+ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
+ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+bash --version 2>&1 | head -n 1
+
+set -eo pipefail
+SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
+TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
+
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
+DOTNET_CHANNEL="STS"
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function FirstJsonValue {
+    perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
+    export DOTNET_EXE="$(command -v dotnet)"
+else
+    # Download install script
+    DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
+    mkdir -p "$TEMP_DIRECTORY"
+    curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
+    chmod +x "$DOTNET_INSTALL_FILE"
+
+    # If global.json exists, load expected version
+    if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
+        DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
+        if [[ "$DOTNET_VERSION" == ""  ]]; then
+            unset DOTNET_VERSION
+        fi
+    fi
+
+    # Install by channel or version
+    DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
+    if [[ -z ${DOTNET_VERSION+x} ]]; then
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
+    else
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
+    fi
+    export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+fi
+
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+fi
+
+"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,0 +1,146 @@
+using System.Linq;
+using JetBrains.Annotations;
+using Nuke.Common;
+using Nuke.Common.Git;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.GitVersion;
+using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
+using static Nuke.Common.Tools.DotNet.DotNetTasks;
+
+class Build : NukeBuild
+{
+  public static int Main () => Execute<Build>(x => x.Compile);
+
+  [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
+  readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
+
+  [Parameter("Collect code coverage. Default is 'true'")] readonly bool? Cover = true;
+
+  [Parameter("Coverage threshold. Default is 80%")] readonly int Threshold = 80;
+
+  [Parameter("Target NuGet server to publish our packages")] readonly string TargetNuGetServer;
+
+  [Parameter("API key for pushing our NuGet packages")] readonly string NuGetApiKey;
+
+  [GitVersion(Framework = "net10.0", NoFetch = true)][CanBeNull] readonly GitVersion GitVersion;
+
+  [Solution] readonly Solution Solution;
+  [GitRepository] readonly GitRepository GitRepository;
+
+  AbsolutePath SourceDirectory => RootDirectory / "src";
+  AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
+  AbsolutePath NuGetArtifactsDirectory => ArtifactsDirectory / "nuget";
+
+  Target Clean => _ => _
+  .Before(Restore)
+  .Executes(() =>
+  {
+      ArtifactsDirectory.CreateOrCleanDirectory();
+      NuGetArtifactsDirectory.CreateOrCleanDirectory();
+  });
+
+  Target Restore => _ => _
+  .Executes(() =>
+  {
+      DotNetRestore(s => s
+    .SetProjectFile(Solution));
+  });
+
+  Target Compile => _ => _
+  .DependsOn(Restore)
+  .Executes(() =>
+  {
+      DotNetBuild(s =>
+      {
+    s = s
+          .SetProjectFile(Solution)
+          .SetConfiguration(Configuration)
+          .EnableNoRestore();
+
+    if (GitVersion != null)
+    {
+          s = s
+      .SetAssemblyVersion($"{GitVersion.Major}.{GitVersion.Minor}.0")
+      .SetFileVersion(GitVersion.MajorMinorPatch)
+      .SetInformationalVersion(GitVersion.InformationalVersion);
+    }
+
+    return s;
+      });
+  });
+
+  Target Test => _ => _
+  .DependsOn(Compile)
+  .Executes(() =>
+  {
+      DotNetTest(s => s
+    .SetConfiguration(Configuration)
+    .SetNoBuild(InvokedTargets.Contains(Compile))
+    .SetProjectFile(Solution)
+    .EnableNoBuild()
+    .SetLoggers("trx")
+    .SetProperty("CollectCoverage", Cover)
+    .SetProperty("CoverletOutput", ArtifactsDirectory / "coverage" / "coverage")
+    .SetProperty("Threshold", Threshold)
+    .SetProperty("ThresholdType", "line")
+    .SetProperty("CoverletOutputFormat", "cobertura")
+    .SetResultsDirectory(ArtifactsDirectory / "tests"));
+  });
+
+  Target Pack => _ => _
+  .After(Test)
+  .DependsOn(Compile)
+  .Executes(() =>
+  {
+      DotNetPack(s =>
+      {
+    s = s
+          .SetProject(SourceDirectory / "ApiKit" / "ApiKit.csproj")
+          .SetConfiguration(Configuration)
+          .EnableNoBuild()
+          .EnableNoRestore()
+          .SetOutputDirectory(NuGetArtifactsDirectory);
+
+    if (GitVersion != null)
+          s = s.SetVersion(GitVersion.NuGetVersionV2);
+
+    return s;
+      });
+  });
+
+  Target Push => _ => _
+  .After(Pack)
+  .Requires(() => OnPublishBranch())
+  .Requires(() => NuGetApiKey)
+  .Requires(() => TargetNuGetServer)
+  .Requires(() => Configuration.Equals(Configuration.Release))
+  .Executes(() =>
+  {
+      NuGetArtifactsDirectory.GlobFiles("*.nupkg")
+    .Where(f => !f.Name.EndsWith("symbols.nupkg"))
+    .ForEach(targetPath =>
+    {
+          DotNetNuGetPush(s => s
+      .SetSource(TargetNuGetServer)
+      .SetApiKey(NuGetApiKey)
+      .SetTargetPath(targetPath)
+      .EnableSkipDuplicate());
+    });
+  });
+
+  bool OnPublishBranch()
+  => GitRepository.IsOnDevelopBranch() ||
+       (GitRepository.Branch?.StartsWithOrdinalIgnoreCase("release-") ?? false) ||
+       GitRepository.IsOnMainBranch() ||
+       IsTagBuild();
+
+  static bool IsTagBuild()
+  {
+    var githubRef = System.Environment.GetEnvironmentVariable("GITHUB_REF") ?? "";
+    return githubRef.StartsWith("refs/tags/v");
+  }
+}

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Nuke.Common.Tooling;
+
+[TypeConverter(typeof(TypeConverter<Configuration>))]
+public class Configuration : Enumeration
+{
+  public static Configuration Debug = new Configuration { Value = nameof(Debug) };
+  public static Configuration Release = new Configuration { Value = nameof(Release) };
+
+  public static implicit operator string(Configuration configuration)
+  {
+    return configuration.Value;
+  }
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+  <OutputType>Exe</OutputType>
+  <TargetFramework>net10.0</TargetFramework>
+  <RootNamespace></RootNamespace>
+  <NoWarn>CS0649;CS0169</NoWarn>
+  <NukeRootDirectory>..</NukeRootDirectory>
+  <NukeScriptDirectory>..</NukeScriptDirectory>
+  <NukeTelemetryVersion>1</NukeTelemetryVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+  <PackageReference Include="Nuke.Common" Version="10.1.0" />
+  <PackageDownload Include="GitVersion.Tool" Version="[6.7.0]" />
+  <!-- Pin transitive deps to patched versions (GHSA-g4vj-cjjj-v7hg, GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf) -->
+  <PackageReference Include="NuGet.Packaging" Version="6.12.5" />
+  <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Adds Nuke build system with Clean, Restore, Compile, Test, Pack, and Push targets
- Adds GitVersion config (GitHubFlow, ContinuousDeployment, v-prefix tags)
- Adds build bootstrappers (build.sh, build.cmd, build.ps1)
- Pins transitive deps NuGet.Packaging (6.12.5) and System.Security.Cryptography.Xml (9.0.15) to patched versions

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive build system with support for multiple platform architectures (x64, x86, Any CPU).
  * Integrated automated versioning and semantic release management.
  * Introduced CI/CD pipeline capabilities including testing, packaging, and publishing workflows.
  * Added code coverage collection and threshold enforcement.

* **Chores**
  * Added cross-platform build scripts for Windows and Unix-like systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->